### PR TITLE
Error with Colab

### DIFF
--- a/run.py
+++ b/run.py
@@ -43,7 +43,7 @@ def run(dataset, option):
     opt = TestOptions().parse()
     global pix2pixmodel
     pix2pixmodel = Pix2Pix4DepthModel(opt)
-    pix2pixmodel.save_dir = './pix2pix/checkpoints/mergemodel'
+    pix2pixmodel.save_dir = './pix2pix/checkpoint/mergemodel'
     pix2pixmodel.load_networks('latest')
     pix2pixmodel.eval()
 


### PR DESCRIPTION
Naming the path with "checkpoints" results in permissions error in Colab, but with "checkpoint" it doesn't.


While using https://github.com/compphoto/BoostingMonocularDepth/blob/main/Boostmonoculardepth.ipynb 
to create the project environment, the subfolder of "mergemodel" cannot be created, and cannot add any files in the folder "BoostingMonocularDepth/pix2pix/checkpoints/"