### PR TITLE
Fix issue with deprecated numpy aliases.

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -97,10 +97,10 @@ def calculateprocessingres(img, basesize, confidence=0.1, scale_threshold=3, who
     grad[grad >= middle] = 1
 
     # dilation kernel with size of the receptive field
-    kernel = np.ones((int(basesize/speed_scale), int(basesize/speed_scale)), np.float)
+    kernel = np.ones((int(basesize/speed_scale), int(basesize/speed_scale)), float)
     # dilation kernel with size of the a quarter of receptive field used to compute k
     # as described in section 6 of main paper
-    kernel2 = np.ones((int(basesize / (4*speed_scale)), int(basesize / (4*speed_scale))), np.float)
+    kernel2 = np.ones((int(basesize / (4*speed_scale)), int(basesize / (4*speed_scale))), float)
 
     # Output resolution limit set by the whole_size_threshold and scale_threshold.
     threshold = min(whole_size_threshold, scale_threshold * max(img.shape[:2]))


### PR DESCRIPTION
This fixes an issue with newer (?) numpy versions where they deprecated the `np.float` alias. Using `float` as suggested in the deprecation note seems to work fine.